### PR TITLE
Corrige erro em applyFormatting com valores não estruturados

### DIFF
--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -197,6 +197,9 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
    * Apply rich text formatting for TypeBot messages
    */
   private applyFormatting(element: any): string {
+    if (typeof element === 'string') return element;
+    if (!element) return '';
+
     let text = '';
 
     if (element.text) {


### PR DESCRIPTION
## Summary
- guard against undefined inputs in Typebot `applyFormatting`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module './test/all.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_685dcd270f3c832bb5bd7a870e9262bc